### PR TITLE
Change Test-Connection to Test-NetConnection

### DIFF
--- a/AutomateDiagnostics.ps1
+++ b/AutomateDiagnostics.ps1
@@ -359,7 +359,7 @@ Function Start-AutomateDiagnostics {
                 }
                 else {
                     $compare_test = if (($hostname -eq $automate_server -and $automate_server -ne "") -or $automate_server -eq "") { $true } else { $false }
-                    Try { $conn_test = Test-Connection $hostname } Catch { 
+                    Try { $conn_test = Test-NetConnection -ComputerName $hostname -Port 443 } Catch { 
                         Write-Verbose "Ping test failed"
                         $conn_test = $false 
                     }


### PR DESCRIPTION
Change Test-Connection to Test-NetConnection on Port 443.

When using Test-Connection for Labtech servers that don't have ICMP enabled, this causes a failure.

By Changing this to Test-NetConnection this should then work as expected.

This should also fix #3 