### PR TITLE
Fix exception if agent has never checked in

### DIFF
--- a/AutomateDiagnostics.ps1
+++ b/AutomateDiagnostics.ps1
@@ -478,7 +478,7 @@ Function Start-AutomateDiagnostics {
             # Get checkin / heartbeat times to DateTime
 	        $lasthbsent = Get-Date $info.HeartbeatLastSent
 	        # This could throw exception because it is only returned if there has been a SuccessStatus
-			if ($info.LastSuccessStatus) {$lastsuccess = Get-Date $info.LastSuccessStatus}
+			if ($info.LastSuccessStatus) {$lastsuccess = Get-Date $info.LastSuccessStatus} 
 	        $lasthbrcv = Get-Date $info.HeartbeatLastReceived
 
             # Check online and heartbeat statuses
@@ -516,7 +516,8 @@ Function Start-AutomateDiagnostics {
                 $ltservice_check = serviceCheck('LTService')
                 $ltsvcmon_check = serviceCheck('LTSVCMon')
                 # Get checkin / heartbeat times to DateTime
-                $lastsuccess = Get-Date $info.LastSuccessStatus
+                # This could throw exception because it is only returned if there has been a SuccessStatus
+				if ($info.LastSuccessStatus) {$lastsuccess = Get-Date $info.LastSuccessStatus} 
                 $lasthbsent = Get-Date $info.HeartbeatLastSent
                 $lasthbrcv = Get-Date $info.HeartbeatLastReceived
                 $online = $lastsuccess -ge $online_threshold

--- a/AutomateDiagnostics.ps1
+++ b/AutomateDiagnostics.ps1
@@ -476,8 +476,9 @@ Function Start-AutomateDiagnostics {
             $info = Get-LTServiceInfo
 
             # Get checkin / heartbeat times to DateTime
-	        $lastsuccess = Get-Date $info.LastSuccessStatus
 	        $lasthbsent = Get-Date $info.HeartbeatLastSent
+	        # This could throw exception because it is only returned if there has been a SuccessStatus
+			if ($info.LastSuccessStatus) {$lastsuccess = Get-Date $info.LastSuccessStatus}
 	        $lasthbrcv = Get-Date $info.HeartbeatLastReceived
 
             # Check online and heartbeat statuses


### PR DESCRIPTION
If the agent has never checked in, $info.LastSuccessStatus isn't returned so calling Get-Date against the implicit $null causes an exception which breaks the JSON output.   This seems to resolve it.   The GUI might be able to handle it better, but at least this gives it better data. 

Thanks very much for this plugin!